### PR TITLE
Fix crash on initial single report

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -115,11 +115,13 @@ assign_t *class_assign(farray_t *fa, farray_t *p)
             }
         }
 
-        /* Compute assignments */
-        c->proto[i] = j;
-        c->dist[i] = min;
-        c->label[i] = p->y[j];
-
+        if (p->len) {
+            /* Compute assignments */
+            c->proto[i] = j;
+            c->dist[i] = min;
+            c->label[i] = p->y[j];
+        }
+        
         if (c->dist[i] > maxdist)
             c->label[i] = 0;
 


### PR DESCRIPTION
if p->len is 0, the loop above this code won't execute and the j index will be out of bounds for p->y.